### PR TITLE
rename loadUrl to loadURL

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ function appReady () {
 function render (indexUrl, output) {
   var win = new BrowserWindow({ width: 0, height: 0, show: false })
   win.on('closed', function () { win = null })
-  win.loadUrl(indexUrl)
+  win.loadURL(indexUrl)
 
   // print to pdf args
   var opts = {


### PR DESCRIPTION
The Url in API names is replaced with URL:
https://github.com/atom/electron/releases