### PR TITLE
Use non-deprecated API and fix output path

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ function render (indexUrl, output) {
   }
 
   win.webContents.on('did-finish-load', function () {
-    win.printToPDF(opts, function (err, data) {
+    win.webContents.printToPDF(opts, function (err, data) {
       if (err) {
         console.error(err)
       }

--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ function render (indexUrl, output) {
         console.error(err)
       }
 
-      fs.writeFile(path.join(process.cwd(), output), data, function (err) {
+      fs.writeFile(path.resolve(output), data, function (err) {
         if (err) {
           console.error(err)
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-pdf",
-  "version": "0.4.3",
+  "version": "0.5.1",
   "description": "A command line tool to generate PDF from URL, HTML or Markdown files",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
API call update is no big deal.

Output path didn't seem to work right at all - paths always had `process.cwd` prefixed to them? I just `path.resolve` them instead.

I bumped the version number since the change might break anyone who has worked around the output path prefixing.