### PR TITLE
add disableCache option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ $ electron-pdf https://fraserxu.me ~/Desktop/fraserxu.pdf
                                  0 - default
                                  1 - none
                                  2 - minimum
+    -d | --disableCache        Disable HTTP caching
 
   Usage
     $ electron-pdf <input> <output>

--- a/index.js
+++ b/index.js
@@ -70,7 +70,12 @@ function appReady () {
 function render (indexUrl, output) {
   var win = new BrowserWindow({ width: 0, height: 0, show: false })
   win.on('closed', function () { win = null })
-  win.loadURL(indexUrl)
+
+  var loadOpts = {}
+  if (argv.d || argv.disableCache) {
+    loadOpts.extraHeaders = 'pragma: no-cache\n'
+  }
+  win.loadURL(indexUrl, loadOpts)
 
   // print to pdf args
   var opts = {

--- a/usage.txt
+++ b/usage.txt
@@ -16,6 +16,7 @@ Options
                                0 - default
                                1 - none
                                2 - minimum
+  -d | --disableCache        Disable HTTP caching
 
 Usage
   $ electron-pdf <input> <output>


### PR DESCRIPTION
Adds a `-d | --disableCache` option to bypass the HTTP cache, as documented in the [electron docs](https://github.com/atom/electron/blob/master/docs/api/web-contents.md#webcontentsloadurlurl-options)