### PR TITLE
fix key name used in printToPDF options

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $ electron-pdf https://fraserxu.me ~/Desktop/fraserxu.pdf
                                  false - default
     -l | --landscape           Boolean - true for landscape, false for portrait.
                                  false - default
-    -m | --marginType          Integer - Specify the type of margins to use
+    -m | --marginsType         Integer - Specify the type of margins to use
                                  0 - default
                                  1 - none
                                  2 - minimum

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ function render (indexUrl, output) {
 
   // print to pdf args
   var opts = {
-    marginType: argv.m || argv.marginType || 0,
+    marginsType: argv.m || argv.marginsType || 0,
     printBackground: argv.p || argv.printBackground || true,
     printSelectionOnly: argv.s || argv.printSelectionOnly || false,
     landscape: argv.l || argv.landscape || false

--- a/usage.txt
+++ b/usage.txt
@@ -12,7 +12,7 @@ Options
                                false - default
   -l | --landscape           Boolean - true for landscape, false for portrait.
                                false - default
-  -m | --marginType          Integer - Specify the type of margins to use
+  -m | --marginsType         Integer - Specify the type of margins to use
                                0 - default
                                1 - none
                                2 - minimum


### PR DESCRIPTION
https://github.com/atom/electron/blob/master/docs/api/web-contents.md#webcontentsprinttopdfoptions-callback