### PR TITLE
Improved CSS 3 support.

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ function appReady () {
  * @param  {String} indexUrl The path to the HTML or url
  */
 function render (indexUrl, output) {
-  var win = new BrowserWindow({ width: 0, height: 0, show: false })
+  var win = new BrowserWindow({ width: 0, height: 0, show: false, webPreferences: {experimentalFeatures: true} })
   win.on('closed', function () { win = null })
 
   var loadOpts = {}


### PR DESCRIPTION
This addressed the issue I was experiencing not being able to leverage newer CSS 3 styles such as making div's behave as columns. This is common in bootstrap grid and other common css boilerplates.

This addresses the following submitted issue: https://github.com/fraserxu/electron-pdf/issues/70