### PR TITLE
Replace marginType with marginsType

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $ electron-pdf https://fraserxu.me ~/Desktop/fraserxu.pdf
                                 "A4" - default
     -l | --landscape           Boolean - true for landscape, false for portrait.
                                  false - default
-    -m | --marginType          Integer - Specify the type of margins to use
+    -m | --marginsType          Integer - Specify the type of margins to use
                                  0 - default
                                  1 - none
                                  2 - minimum

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ function render (indexUrl, output) {
 
   // print to pdf args
   var opts = {
-    marginType: argv.m || argv.marginType || 0,
+    marginsType: argv.m || argv.marginsType || argv.marginType || 0,
     printBackground: argv.b || argv.printBackground || true,
     printSelectionOnly: argv.s || argv.printSelectionOnly || false,
     pageSize: argv.p || argv.pageSize || 'A4',

--- a/usage.txt
+++ b/usage.txt
@@ -14,7 +14,7 @@ Options
                                "A4" - default
   -l | --landscape           Boolean - true for landscape, false for portrait.
                                false - default
-  -m | --marginType          Integer - Specify the type of margins to use
+  -m | --marginsType          Integer - Specify the type of margins to use
                                0 - default
                                1 - none
                                2 - minimum


### PR DESCRIPTION
Electron changed the name of the option from `marginType` to `marginsType`. I changed it here, but made the old way compatible, too.

See Electron documentation here: https://github.com/electron/electron/blob/master/docs/api/web-contents.md#webcontentsprinttopdfoptions-callback