### PR TITLE
Parse pageSize dimensions in constructor

### DIFF
--- a/lib/charge.js
+++ b/lib/charge.js
@@ -15,10 +15,6 @@ if (argv.version) {
   process.exit(0)
 }
 
-if (argv.pageSize && argv.pageSize[0] === '{') {
-  argv.pageSize = JSON.parse(argv.pageSize)
-}
-
 if (argv.help || !input || !output) {
   usage(1)
 } else {

--- a/lib/exportJob.js
+++ b/lib/exportJob.js
@@ -42,6 +42,10 @@ class ExportJob extends EventEmitter {
     this.input = input
     this.output = output
     this.args = args
+
+    if (_.startsWith(this.args.pageSize, '{')) {
+      this.args.pageSize = JSON.parse(this.args.pageSize)
+    }
   }
 
   // ***************************************************************************

--- a/test/exportJob-test.js
+++ b/test/exportJob-test.js
@@ -1,7 +1,17 @@
 import {test} from 'ava'
 
 import ExportJob from '../lib/exportJob'
-const job = new ExportJob()
+
+const micronDims = {
+  width: 304800,
+  height: 228600
+}
+
+const options = {
+  pageSize: JSON.stringify(micronDims)
+}
+
+const job = new ExportJob('input', 'output', options)
 
 test('getPageDimensions_Letter_Portrait', t => {
   const dim = job._getPageDimensions('Letter', false)
@@ -14,12 +24,11 @@ test('getPageDimensions_Letter_Landscape', t => {
 })
 
 test('getPageDimensions_object', t => {
-  const micronDims = {
-    width: ExportJob.MICRONS_INCH_RATIO,
-    height: ExportJob.MICRONS_INCH_RATIO
-  }
   const dim = job._getPageDimensions(micronDims, false)
-  t.deepEqual(dim, {x: ExportJob.HTML_DPI, y: ExportJob.HTML_DPI})
+  t.deepEqual(dim, {
+    x: ExportJob.HTML_DPI * 12,
+    y: ExportJob.HTML_DPI * 9
+  })
 })
 
 // Cookie Tests


### PR DESCRIPTION
pdf micron dimensions were previously only supported using the CLI, this is required for them to be parsed when using the API directly