### PR TITLE
Add ability to export html as well (for SPA server-side rendering)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,19 @@ available from the Electron API.  See the following options for usage.
 
 Inspired by [electron-mocha](https://github.com/jprichardson/electron-mocha)
 
+### Other Formats
+
+Want to use the same options, but export to PNG or snapshot the rendered HTML?
+Just set the output filename to end in .png or .html instead!
+
+```
+  Examples
+    $ electron-pdf http://fraserxu.me ~/Desktop/fraserxu.pdf
+    $ electron-pdf http://fraserxu.me ~/Desktop/fraserxu.html
+    $ electron-pdf http://fraserxu.me ~/Desktop/fraserxu.png
+
+```
+
 ### Extensions
 
 If you need powerpoint support, [pdf-powerpoint](https://www.npmjs.com/package/pdf-powerpoint) 

--- a/lib/exportJob.js
+++ b/lib/exportJob.js
@@ -452,10 +452,23 @@ class ExportJob extends EventEmitter {
 
       if (outputFile.toLowerCase().endsWith('.png')) {
         this._captureImage(window, outputFile, done)
+      } else if (outputFile.toLowerCase().endsWith('.html')) {
+        this._captureHtml(window, outputFile, done)
       } else {
         this._capturePDF(args, window, done, outputFile)
       }
     }
+  }
+
+  _captureHtml (window, outputFile, done) {
+    window.webContents.executeJavaScript('document.documentElement.outerHTML', result => {
+      const target = path.resolve(outputFile)
+      fs.writeFile(target, result, function (err) {
+        this.emit('window.capture.end', {file: target, error: err})
+        this.emit('export-complete', {file: target})
+        done(err, target)
+      }.bind(this))
+    })
   }
 
   _captureImage (window, outputFile, done) {


### PR DESCRIPTION
We're looking to replace our current setup for PDF generation with electron-pdf in our React-based single page app. Currently we use a two-step process to capture PDFs of our dashboards:

1. export html via PhantomJS worker (this helps wkhtmltopdf, because some of what we've been doing with React and D3.js doesn't seem to render well directly in the old forked version of QTWebkit it relies on)
2. convert the exported html to PDF

This process enabled us to also do server-side rendering for our dashboards, which is a neat way to allow HTML export for our React app in a way that doesn't require any JS for the end user. Ideally I'd like to tear out and replace the HTML export from PhantomJS and use the same Electron-based system for consistency, and this seemed like the easiest place to do it. 

With these changes I can use the same event system to wait for both PDF and HTML to be rendered, etc. 