### PR TITLE
Define default options for a job

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ app.post('/pdfexport', function(req,res){
 	   */
 	  inMemory: false 
 	}
+	const options = {
+  		pageSize : "A4"
+	}
 	exporter.createJob(source, target, options, jobOptions).then( job => {
 	job.on('job-complete', (r) => {
     		console.log('pdf files:', r.results)


### PR DESCRIPTION
Hi,

i spend a long time figuring why the express example didn't work. Default values was missing. 

I added it to readme but maybe it could be better to add a check in exportjob.js ?

In _getBrowserConfiguration, if there is no options, args is undefined and it silently break