### PR TITLE
inconsistency between README and actual implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ If you are finding that the [event is not effective](https://github.com/fraserxu
 
 ```javascript
   var eventEmitInterval = setInterval(function () {
-    document.dispatchEvent(new Event('view-ready'))
+    document.body.dispatchEvent(new Event('view-ready'))
   }, 25)
 
   document.body.addEventListener('view-ready-acknowledged', function(){

--- a/lib/exportJob.js
+++ b/lib/exportJob.js
@@ -469,7 +469,7 @@ class ExportJob extends EventEmitter {
                    function(event) {
                      ipcRenderer.send('${IPC_MAIN_CHANNEL_RENDER}', '${this.jobId}', event.detail)
                      // #169 - allows clients to send event until we acknowledge receipt
-                     document.dispatchEvent(new Event('${eventName}-acknowledged'))
+                     document.body.dispatchEvent(new Event('${eventName}-acknowledged'))
                    }
                  )`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-pdf",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "A command line tool to generate PDF from URL, HTML or Markdown files",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
This should make it more consistent so it always uses `document.body` for this "view-ready" events.

Right now for v1.1.8 I have to `dispatchEvent` on `document.body` and `addEventListener` on `document`

