### PR TITLE
Support logger injection

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,8 @@ const electron = require('electron')
 const minimist = require('minimist')
 
 const argOptions = require('./options')
+const setLogger = require('./logger').set
+
 const ExportJob = require('./exportJob')
 const Source = require('./source')
 const source = new Source()
@@ -25,11 +27,13 @@ class PDFExporter extends EventEmitter {
    * @param opts
    * @param {boolean} [opts.resilient=false] set to true to catch and
    * log all uncaught exception but leave things running
+   * @param {object} [opts.loggers] Allows client to use its own logging implementation
    */
   constructor (opts) {
     super()
     this.options = opts || {}
     this.reslientMode = this.options.resilient || false
+    setLogger(this.options.loggers)
   }
 
   /**

--- a/lib/windowMaid.js
+++ b/lib/windowMaid.js
@@ -1,7 +1,9 @@
 // Third Party Modules
 const _ = require('lodash')
 
-const logger = require('./logger')
+const errorLogger = require('./logger').error
+const infoLogger = require('./logger')
+const debugLogger = require('./logger').debug
 
 /** How long a window can remain open before it is terminated, in milliseconds */
 const HUNG_WINDOW_THRESHOLD = process.env.ELECTRONPDF_WINDOW_LIFE_THRESHOLD || 1000 * 60 * 5 /* minutes */
@@ -52,13 +54,13 @@ const windowMaid = {
     const th = threshold || HUNG_WINDOW_THRESHOLD
     const hungWindows = _.filter(windowCache, e => now - e.lastUsed >= th)
 
-    logger(`checking hung windows-> ` +
+    debugLogger(`checking hung windows-> ` +
       `total windows: ${_.size(windowCache)}, ` +
       `hung windows: ${_.size(hungWindows)}, ` +
       `threshold: ${th}`)
 
     _.forEach(hungWindows, e => {
-      logger('destroying hung window: ', e.id)
+      infoLogger('destroying hung window: ', e.id)
       const destroyable = e.job && e.window && !e.window.isDestroyed()
       if (destroyable) {
         const windowContext = {
@@ -69,7 +71,7 @@ const windowMaid = {
         delete windowCache[e.id]
         e.job.destroy()
       } else {
-        logger('Warning: a window was left in the cache that was already destroyed, do proper cleanup')
+        errorLogger('a window was left in the cache that was already destroyed, do proper cleanup')
         delete windowCache[e.id]
       }
     })

--- a/lib/windowTailor.js
+++ b/lib/windowTailor.js
@@ -1,5 +1,5 @@
 /** Used to calculate browser dimensions based on PDF size */
-const HTML_DPI = 96 // dots per inch
+const HTML_DPI = 96 // dots per inch (HTML:96), PDF:72
 
 /** Used to determine browser size using a Micron -> Inch -> Pixel conversion */
 const MICRONS_INCH_RATIO = 25400


### PR DESCRIPTION
logs are littered with: `checking hung windows...` 
this allows the client to inject its own logger and logs this check at debug instead of info, to better suit production configurations

(most logging his handled through event listeners in the client, but some things like this are not really event worthy because they are outside the bounds of a job)