### PR TITLE
Corrected url formatting

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -1,6 +1,5 @@
 var assert = require('assert')
 var assign = require('object-assign')
-var path = require('path')
 var url = require('url')
 
 function encode (args) {

--- a/lib/args.js
+++ b/lib/args.js
@@ -21,7 +21,8 @@ function urlWithArgs (urlOrFile, args) {
   } else { // presumably a file url
     u = url.format({
       protocol: 'file',
-      pathname: path.resolve(urlOrFile),
+      pathname: url.parse(urlOrFile).pathname,
+      search: url.parse(urlOrFile).query,
       slashes: true,
       hash: args
     })

--- a/test/args-test.js
+++ b/test/args-test.js
@@ -1,0 +1,30 @@
+import { test } from 'ava'
+
+import Args from '../lib/args'
+
+test('encode empty', t => {
+  const args = {}
+  const encoded = Args.encode(args)
+  t.deepEqual(encoded, '%7B%7D')
+})
+
+test('file with query string', t => {
+  const url = '/test/file.html?p=hello&n=world'
+  const args = {}
+  const newUrl = Args.urlWithArgs(url, args)
+  t.deepEqual(newUrl, 'file:///test/file.html?p=hello&n=world#%7B%7D')
+})
+
+test('file with no query string', t => {
+  const url = '/test/file.html'
+  const args = {}
+  const newUrl = Args.urlWithArgs(url, args)
+  t.deepEqual(newUrl, 'file:///test/file.html#%7B%7D')
+})
+
+test('http url with query string', t => {
+  const url = 'http://electronpdf.com/test/file.html?p=hello'
+  const args = {}
+  const newUrl = Args.urlWithArgs(url, args)
+  t.deepEqual(newUrl, 'http://electronpdf.com/test/file.html?p=hello#%7B%7D')
+})


### PR DESCRIPTION
I called `electron-pdf.createJob()` with this url : `/home/default/myFile.html?print-pdf`.

Before my changes, `url.format` formatted the URL to 
`/home/default/myFile.html%3Fprint-pdf#%7B%7D`. 
The generated PDF was a blank page.

After my changes, the formatted URL is 
`/home/default/myFile.html?print-pdf#%7B%7D` because I used the correct properties for the `url.format()` parameter object.
The generated PDF is as expected.