### PR TITLE
Fix to not remove Hash (#) from URL from bug #202

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -10,7 +10,6 @@ function encode (args) {
 }
 
 function urlWithArgs (urlOrFile, args) {
-  args = args || null
   args = encode(args)
 
   var u

--- a/lib/args.js
+++ b/lib/args.js
@@ -14,7 +14,7 @@ function urlWithArgs (urlOrFile, args) {
 
   var u
   var urlData = url.parse(urlOrFile)
-  if (urlOrFile.indexOf('http') === 0) {
+  if (urlData.protocol === 'http:') {
     var hash = args || urlData.hash
     u = url.format(assign(urlData, { hash: hash }))
   } else { // presumably a file url

--- a/lib/args.js
+++ b/lib/args.js
@@ -10,12 +10,13 @@ function encode (args) {
 }
 
 function urlWithArgs (urlOrFile, args) {
+  args = args || null
   args = encode(args)
 
   var u
   if (urlOrFile.indexOf('http') === 0) {
     var urlData = url.parse(urlOrFile)
-    var hash = urlData.hash || args ? args : undefined
+    var hash = args || urlData.hash
     u = url.format(assign(urlData, { hash: hash }))
   } else { // presumably a file url
     u = url.format({

--- a/lib/args.js
+++ b/lib/args.js
@@ -13,8 +13,8 @@ function urlWithArgs (urlOrFile, args) {
   args = encode(args)
 
   var u
+  var urlData = url.parse(urlOrFile)
   if (urlOrFile.indexOf('http') === 0) {
-    var urlData = url.parse(urlOrFile)
     var hash = args || urlData.hash
     u = url.format(assign(urlData, { hash: hash }))
   } else { // presumably a file url
@@ -23,7 +23,7 @@ function urlWithArgs (urlOrFile, args) {
       pathname: url.parse(urlOrFile).pathname,
       search: url.parse(urlOrFile).query,
       slashes: true,
-      hash: args
+      hash: args || urlData.hash
     })
   }
 

--- a/lib/exportJob.js
+++ b/lib/exportJob.js
@@ -388,7 +388,7 @@ class ExportJob extends EventEmitter {
       loadOpts.extraHeaders += 'pragma: no-cache\n'
     }
     this.emit(`${RENDER_EVENT_PREFIX}loadurl`, { url: url })
-    window.loadURL(wargs.urlWithArgs(url, {}), loadOpts)
+    window.loadURL(wargs.urlWithArgs(url), loadOpts)
   }
 
   // Page Load & Rendering
@@ -435,7 +435,7 @@ class ExportJob extends EventEmitter {
   _executeJSListener (eventName, ipcListener, generateFunction, window) {
     // event.detail will only exist if a CustomEvent was emitted
     const cmd = `var ipcRenderer = require('electron').ipcRenderer
-                 document.body.addEventListener('${eventName}', 
+                 document.body.addEventListener('${eventName}',
                    function(event) {
                      ipcRenderer.send('${IPC_MAIN_CHANNEL_RENDER}', '${this.jobId}', event.detail)
                      // #169 - allows clients to send event until we acknowledge receipt

--- a/lib/exportJob.js
+++ b/lib/exportJob.js
@@ -388,7 +388,7 @@ class ExportJob extends EventEmitter {
       loadOpts.extraHeaders += 'pragma: no-cache\n'
     }
     this.emit(`${RENDER_EVENT_PREFIX}loadurl`, { url: url })
-    window.loadURL(wargs.urlWithArgs(url), loadOpts)
+    window.loadURL(wargs.urlWithArgs(url, null), loadOpts)
   }
 
   // Page Load & Rendering

--- a/test/args-test.js
+++ b/test/args-test.js
@@ -2,29 +2,114 @@ import { test } from 'ava'
 
 import Args from '../lib/args'
 
-test('encode empty', t => {
-  const args = {}
-  const encoded = Args.encode(args)
-  t.deepEqual(encoded, '%7B%7D')
-})
-
-test('file with query string', t => {
+test('file with query string and arguments', t => {
   const url = '/test/file.html?p=hello&n=world'
   const args = {}
   const newUrl = Args.urlWithArgs(url, args)
   t.deepEqual(newUrl, 'file:///test/file.html?p=hello&n=world#%7B%7D')
 })
 
-test('file with no query string', t => {
+test('file with query string and no arguments', t => {
+  const url = '/test/file.html?p=hello&n=world'
+  const args = null
+  const newUrl = Args.urlWithArgs(url, args)
+  t.deepEqual(newUrl, 'file:///test/file.html?p=hello&n=world')
+})
+
+test('file with no query string but with arguments', t => {
   const url = '/test/file.html'
   const args = {}
   const newUrl = Args.urlWithArgs(url, args)
   t.deepEqual(newUrl, 'file:///test/file.html#%7B%7D')
 })
 
-test('http url with query string', t => {
+test('file with no query string and no arguments', t => {
+  const url = '/test/file.html'
+  const args = null
+  const newUrl = Args.urlWithArgs(url, args)
+  t.deepEqual(newUrl, 'file:///test/file.html')
+})
+
+test('file with query string and arguments in URL', t => {
+  const url = '/test/file.html?p=hello&n=world#!/123'
+  const args = null
+  const newUrl = Args.urlWithArgs(url, args)
+  t.deepEqual(newUrl, 'file:///test/file.html?p=hello&n=world#!/123')
+})
+
+test('file with no query string and with arguments in URL', t => {
+  const url = '/test/file.html#!/123'
+  const args = null
+  const newUrl = Args.urlWithArgs(url, args)
+  t.deepEqual(newUrl, 'file:///test/file.html#!/123')
+})
+
+test('file with query string replacing arguments from URL', t => {
+  const url = '/test/file.html?p=hello&n=world#!/123'
+  const args = {}
+  const newUrl = Args.urlWithArgs(url, args)
+  t.deepEqual(newUrl, 'file:///test/file.html?p=hello&n=world#%7B%7D')
+})
+
+test('file with no query string and with arguments in URL', t => {
+  const url = '/test/file.html#!/123'
+  const args = null
+  const newUrl = Args.urlWithArgs(url, args)
+  t.deepEqual(newUrl, 'file:///test/file.html#!/123')
+})
+
+test('http url with query string and arguments', t => {
   const url = 'http://electronpdf.com/test/file.html?p=hello'
   const args = {}
   const newUrl = Args.urlWithArgs(url, args)
   t.deepEqual(newUrl, 'http://electronpdf.com/test/file.html?p=hello#%7B%7D')
+})
+
+test('http url with query string and no arguments', t => {
+  const url = 'http://electronpdf.com/test/file.html?p=hello'
+  const args = null
+  const newUrl = Args.urlWithArgs(url, args)
+  t.deepEqual(newUrl, 'http://electronpdf.com/test/file.html?p=hello')
+})
+
+test('http url with no query string but with arguments', t => {
+  const url = 'http://electronpdf.com/test/file.html'
+  const args = {}
+  const newUrl = Args.urlWithArgs(url, args)
+  t.deepEqual(newUrl, 'http://electronpdf.com/test/file.html#%7B%7D')
+})
+
+test('http url with no query string and no arguments', t => {
+  const url = 'http://electronpdf.com/test/file.html'
+  const args = null
+  const newUrl = Args.urlWithArgs(url, args)
+  t.deepEqual(newUrl, 'http://electronpdf.com/test/file.html')
+})
+
+test('http url with query string and arguments in URL', t => {
+  const url = 'http://electronpdf.com/test/file.html?p=hello#!/123'
+  const args = null
+  const newUrl = Args.urlWithArgs(url, args)
+  t.deepEqual(newUrl, 'http://electronpdf.com/test/file.html?p=hello#!/123')
+})
+
+test('http url with no query string and with arguments in URL', t => {
+  const url = 'http://electronpdf.com/test/file.html#!/123'
+  const args = null
+  const newUrl = Args.urlWithArgs(url, args)
+  t.deepEqual(newUrl, 'http://electronpdf.com/test/file.html#!/123')
+})
+
+test('http url with query string replacing arguments from URL', t => {
+  const url = 'http://electronpdf.com/test/file.html?p=hello#!/123'
+  const args = {}
+  const newUrl = Args.urlWithArgs(url, args)
+  t.deepEqual(newUrl, 'http://electronpdf.com/test/file.html?p=hello#%7B%7D')
+})
+
+test('http url with no query string replacing arguments in URL', t => {
+  const url = 'http://electronpdf.com/test/file.html#!/123'
+  const args = {}
+  const newUrl = Args.urlWithArgs(url, args)
+  t.deepEqual(newUrl, 'http://electronpdf.com/test/file.html#%7B%7D')
 })


### PR DESCRIPTION
Adding ability to use URL arguments if passed, or use the ones already defined in the URL.
Hash now does not get removed from the URL.