### PR TITLE
Fixes #220 need to keep contextIsolation disabled 

### DIFF
--- a/lib/exportJob.js
+++ b/lib/exportJob.js
@@ -351,8 +351,8 @@ class ExportJob extends EventEmitter {
       show: false,
       center: true, // Display in center of screen,
       webPreferences: {
-          nodeIntegration: trustRemoteContent,
-          contextIsolation: true
+        nodeIntegration: trustRemoteContent,
+        preload: path.join(__dirname, 'preload.js')
       }
     }
 
@@ -438,10 +438,9 @@ class ExportJob extends EventEmitter {
    */
   _executeJSListener (eventName, ipcListener, generateFunction, window) {
     // event.detail will only exist if a CustomEvent was emitted
-    const cmd = `var ipcRenderer = require('electron').ipcRenderer
-                 document.body.addEventListener('${eventName}',
+    const cmd = `document.body.addEventListener('${eventName}',
                    function(event) {
-                     ipcRenderer.send('${IPC_MAIN_CHANNEL_RENDER}', '${this.jobId}', event.detail)
+                     ipcApi.send('${IPC_MAIN_CHANNEL_RENDER}', '${this.jobId}', event.detail)
                      // #169 - allows clients to send event until we acknowledge receipt
                      document.body.dispatchEvent(new Event('${eventName}-acknowledged'))
                    }
@@ -487,7 +486,7 @@ class ExportJob extends EventEmitter {
     const listener = (name, jobId, customEventDetail) => {
       // Multiple listeners could be active concurrently,
       // make sure we have the right event for this job
-      // logger(`this.jobId:${this.jobId}, event job id:${jobId}`)
+      // debugLogger(`ready event received. this.jobId:${this.jobId}, event job id:${jobId}`)
       if (this.jobId === jobId) {
         this.emit('window.event.wait.end', {})
         if (this.readyEventObserver) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -2,7 +2,7 @@
 //  TODO: Generate Usage Doc from argv options
 
 var options = {
-  boolean: ['printBackground', 'landscape', 'printSelectionOnly', 'trustRemoteContent', 'waitForJSEvent'],
+  boolean: ['printBackground', 'landscape', 'printSelectionOnly', 'trustRemoteContent'],
   alias: {
     'input': 'i',
     'output': 'o',
@@ -31,8 +31,7 @@ var options = {
     'pageSize': 'A4',
     'printBackground': true,
     'printSelectionOnly': false,
-    'trustRemoteContent': false,
-    'waitForJSEvent': false
+    'trustRemoteContent': false
   }
 }
 

--- a/lib/preload.js
+++ b/lib/preload.js
@@ -7,6 +7,7 @@ const privateApi = {
 }
 
 // accessed from exportJob.js#_executeJSListener
+// eslint-disable-next-line no-undef
 ipcApi = {
   send (event, jobId, detail) {
     privateApi.renderer.send(event, jobId, detail)

--- a/lib/preload.js
+++ b/lib/preload.js
@@ -1,0 +1,14 @@
+const {ipcRenderer} = require('electron')
+
+const privateApi = {
+  // Have to assign ipcRenderer here or it will not be available
+  // after preload.js terminates
+  renderer: ipcRenderer
+}
+
+// accessed from exportJob.js#_executeJSListener
+ipcApi = {
+  send (event, jobId, detail) {
+    privateApi.renderer.send(event, jobId, detail)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-pdf",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "A command line tool to generate PDF from URL, HTML or Markdown files",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
No IPC can happen with contextIsolation turned on, which prevents the ready event functionality from working.