### PR TITLE
HotFix: Autoclosing the window will lead to orphaned windows in the windowMaid

### DIFF
--- a/lib/exportJob.js
+++ b/lib/exportJob.js
@@ -144,7 +144,7 @@ class ExportJob extends EventEmitter {
 
     async.series(windowEvents, (err, results) => {
       if (this.options.closeWindow) {
-        win.close()
+        this.destroy()
         this.emit(`${RENDER_EVENT_PREFIX}window.close`)
       }
       /**


### PR DESCRIPTION
I noticed a small bug while implementing the BrowserWindow pool (#234).

When using the default setting of closing a window automatically, the windowMaid would not be notified and say that there are active windows.

I used the destroy method to avoid duplicate code.