### PR TITLE
Fix silent crash when using Electron 4.x under Windows

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -5,6 +5,7 @@ var electronPath = require('electron')
 
 var args = process.argv.slice(2)
 
+args.unshift('--')
 args.unshift(path.resolve(path.join(__dirname, './lib/charge.js')))
 
 var electron = spawn(electronPath, args, {

--- a/lib/charge.js
+++ b/lib/charge.js
@@ -7,7 +7,7 @@ const Exporter = require('./index')
 const argOptions = require('./options')
 const logger = require('./logger')
 
-const argv = parseArgs(process.argv.slice(2), argOptions)
+const argv = parseArgs(process.argv.slice(3), argOptions)
 const input = argv._[0] || argv.input
 const output = argv._[1] || argv.output
 


### PR DESCRIPTION
I'm experiencing a rather bizarre issue when using any of the 4.0.x releases of electron-pdf under Windows 10 version 1903. Whenever a URL with a protocol is used as the input argument (`http://`, `https://`, `file:///`, etc.), the Electron process will immediately exit with a return code of zero and no output whatsoever. As a result, electron-pdf silently fails, never even loading the requested page, let alone rendering it to PDF. This issue does not occur when using a local file path, or when using the 1.3.x or 1.2.x releases of electron-pdf, so presumably it's an issue in the 4.0.x series of Electron.

The workaround for this bug is to inject a `--` argument between the script path and the remaining arguments. The `--` syntax is widely used amongst command-line tools as a delimiter between arguments to the tool itself and arguments to a script being run by the tool, and is often employed to help prevent any confusion regarding the intended logical groupings of the arguments. Evidently Electron also supports this syntax, and the inclusion of the `--` argument circumvents whatever underlying bug is causing the silent failures.