### PR TITLE
Fixed multiple issues with regard to capturing file downloads

### DIFF
--- a/lib/exportJob.js
+++ b/lib/exportJob.js
@@ -404,14 +404,14 @@ class ExportJob extends EventEmitter {
 
   _saveDownload (win) {
     const downloadPromise = new Promise((resolve, reject) => {
-      win.webContents.session.on('will-download', (event, item, webContents) => {
+      win.webContents.session.once('will-download', (event, item, webContents) => {
         // Set the save path, making Electron not to prompt a save dialog.
         item.setSavePath(this.output)
         item.once('done', (event, state) => resolve({ event, state }))
       })
     })
 
-    this._renderAndCollectOutput(win, (win, inputIndex, outputDoneFn) => {
+    this._renderAndCollectOutput(win, (context, outputDoneFn) => {
       downloadPromise.then(({ state }) => {
         if (state === 'completed') {
           this._emitResourceEvents(null, this.output, outputDoneFn)
@@ -474,9 +474,7 @@ class ExportJob extends EventEmitter {
     this._initializeWindowForResource(orientation === 'landscape')
     const generateFunction = generateFn.bind(this, context, outputDoneFn)
     const waitFunction = this._waitForPage.bind(this, window, generateFunction, this.args.outputWait)
-    // Need a new listener to generate the resource
-    window.webContents.removeAllListeners('did-finish-load')
-    window.webContents.on('did-finish-load', waitFunction)
+    window.webContents.once('did-finish-load', waitFunction)
     this._loadURL(window, uriPath)
   }
 
@@ -494,8 +492,12 @@ class ExportJob extends EventEmitter {
    * @private
    */
   _waitForPage (window, generateFunction, waitTime) {
-    const waitForJSEvent = this.args.waitForJSEvent
-    if (waitForJSEvent) {
+    const { noprint, waitForJSEvent } = this.args
+    if (noprint) {
+      // If the page isn't being captured don't wait at all
+      // (e.g. A file download is initiated by the client using it's own event listener)
+      generateFunction()
+    } else if (waitForJSEvent) {
       this._waitForBrowserEvent(waitForJSEvent, window, generateFunction)
     } else {
       setTimeout(generateFunction, waitTime)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-pdf",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-pdf",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "description": "A command line tool to generate PDF from URL, HTML or Markdown files",
   "main": "lib/index.js",
   "scripts": {
@@ -57,6 +57,7 @@
   },
   "ava": {
     "concurrency": 5,
+    "timeout": "1s",
     "failFast": true,
     "tap": true,
     "powerAssert": false

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "ava": {
     "concurrency": 5,
-    "timeout": "1s",
+    "timeout": "5s",
     "failFast": true,
     "tap": true,
     "powerAssert": false

--- a/test/exportJob-test.js
+++ b/test/exportJob-test.js
@@ -162,6 +162,15 @@ test.cb('handlePDF_inMemory', t => {
   inMemJob._handlePDF('output.pdf', cb, err, data)
 })
 
+test.cb(`_waitForPage with --noprint adds no wait and invokes generate function immediately`, t => {
+  args.noprint = true
+
+  // generateFn being called immediately is what we're verifying
+  const generateFn = () => t.end()
+
+  job._waitForPage(undefined, generateFn, 10000)
+})
+
 // Support Functions
 /**
  * Stubs the windows.sessionn.cookies object and provides access


### PR DESCRIPTION
1. window event listeners should use `once` instead of `on`
2. Corrected the arguments bound to `generateFunction` (missed from last change)
3. If `noprint` is specified, waiting should be disabled (both `readyEvent` and `wait`).  The client is expected to block and initiate the file download when appropriate.