### PR TITLE
Add option to ignore untrusted certificate errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ available from the Electron API.  See the following options for usage.
     
     -w | --outputWait          Integer – Time to wait (in MS) between page load and PDF creation.  
                                          If used in conjunction with -e this will override the default timeout of 10 seconds    
+    -ignoreCertificateErrors  Boolean - Whether to accept self-signed and untrusted certificates
 ```
 
 Find more information on [Electron Security here](https://github.com/electron/electron/blob/master/docs/tutorial/security.md).

--- a/lib/index.js
+++ b/lib/index.js
@@ -107,6 +107,17 @@ class PDFExporter extends EventEmitter {
       throw msg
     }
 
+    // https://stackoverflow.com/a/46789486/30665
+    if (args.ignoreCertificateErrors) {
+       // SSL/TSL: this is the self signed certificate support
+      electronApp.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
+        // On certificate error we disable default behaviour (stop loading the page)
+        // and we then say "it is all fine - true" to the callback
+        event.preventDefault()
+        callback(true)
+      })
+    }
+
     // charge.js interprets the args, but this method should also support raw args
     if (args instanceof Array) {
       args = minimist(args, argOptions)


### PR DESCRIPTION
If the commandline option `--ignoreCertificateErrors` is set to true Electron won't fail if it encounters an invalid or untrusted certificates when loading the page.

Fixes #227 