### PR TITLE
Make disableCache a proper boolean arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ available from the Electron API.  See the following options for usage.
     
     -c | --css                 String - The path to custom CSS (can be specified more than once)
     
-    -d | --disableCache        Disable HTTP caching
+    -d | --disableCache        Boolean - Disable HTTP caching
                                  false - default
     
     -e | --waitForJSEvent      String - The name of the event to wait before PDF creation

--- a/lib/exportJob.js
+++ b/lib/exportJob.js
@@ -495,7 +495,7 @@ class ExportJob extends EventEmitter {
     const { noprint, waitForJSEvent } = this.args
     if (noprint) {
       // If the page isn't being captured don't wait at all
-      // (e.g. A file download is initiated by the client using it's own event listener)
+      // (e.g. A file download is initiated by the client using its own event listener)
       generateFunction()
     } else if (waitForJSEvent) {
       this._waitForBrowserEvent(waitForJSEvent, window, generateFunction)
@@ -616,7 +616,7 @@ class ExportJob extends EventEmitter {
 
     this.readyEventObserver(customEventDetail).then(context => {
       /**
-       * Fires when an observer fulfills it's promise
+       * Fires when an observer fulfills its promise
        * @event PDFExporter#window.observer.end
        * @type {object}
        */
@@ -712,7 +712,7 @@ class ExportJob extends EventEmitter {
             this._handlePDF(outputFile, done, error, undefined)
           })
           .finally(() => {
-            debugLogger(`printToPDF has fulfilled it's promise`)
+            debugLogger(`printToPDF has fulfilled its promise`)
           })
     } catch (e) {
       errorLogger(e)

--- a/lib/options.js
+++ b/lib/options.js
@@ -2,7 +2,7 @@
 //  TODO: Generate Usage Doc from argv options
 
 var options = {
-  boolean: ['printBackground', 'landscape', 'printSelectionOnly', 'trustRemoteContent', 'ignoreCertificateErrors'],
+  boolean: ['printBackground', 'landscape', 'printSelectionOnly', 'trustRemoteContent', 'ignoreCertificateErrors', 'disableCache'],
   alias: {
     'input': 'i',
     'output': 'o',
@@ -45,7 +45,8 @@ var options = {
     'pageSize': 'A4',
     'printBackground': true,
     'printSelectionOnly': false,
-    'trustRemoteContent': false
+    'trustRemoteContent': false,
+    'disableCache': false
   }
 }
 

--- a/test/logger-test.js
+++ b/test/logger-test.js
@@ -5,7 +5,7 @@ import _ from 'lodash'
 import { set, info } from '../lib/logger'
 
 /**
- * Shows usage for clients, and validates tha it works!
+ * Shows usage for clients, and validates that it works!
  */
 test('set loggers', t => {
   let msg

--- a/usage.txt
+++ b/usage.txt
@@ -19,8 +19,9 @@ Options
                                0 - default
                                1 - none (electron-pdf default setting)
                                2 - minimum
-  -d | --disableCache        Disable HTTP caching
-  -w | --outputWait          Integer – Time to wait (in MS) between page load and PDF creation.  If used in conjunction with -e this will override the default timeout of 10 seconds
+  -d | --disableCache        Boolean - Disable HTTP caching
+                               false - default
+  -w | --outputWait          Integer - Time to wait (in MS) between page load and PDF creation.  If used in conjunction with -e this will override the default timeout of 10 seconds
   -e | --waitForJSEvent      String - The name of the event to wait before PDF creation
                                'view-ready' - default
   -t | --trustRemoteContent  Boolean - Trust remote content loaded in the Electron webview.


### PR DESCRIPTION
If you called `electron-pdf --disableCache http://example.com example.pdf` it would print the usage message. You would have to do something like `electron-pdf --disableCache true http://example.com example.pdf`

Now it works like the other boolean arguments.

I also included some minor grammar and spelling fixes.