### PR TITLE
Enable context isolation

### DIFF
--- a/lib/exportJob.js
+++ b/lib/exportJob.js
@@ -360,6 +360,7 @@ class ExportJob extends EventEmitter {
       center: true, // Display in center of screen,
       webPreferences: {
         nodeIntegration: trustRemoteContent,
+        contextIsolation: true, // default from electron v12 on
         preload: path.join(__dirname, 'preload.js')
       }
     }

--- a/lib/preload.js
+++ b/lib/preload.js
@@ -1,7 +1,7 @@
 // Get some logs when things go horribly wrong
 require('./sentry')
 const _ = require('lodash')
-const { ipcRenderer } = require('electron')
+const { ipcRenderer, contextBridge } = require('electron')
 
 const privateApi = {
   // Have to assign ipcRenderer here or it will not be available
@@ -37,8 +37,7 @@ function sendStats (options = {}) {
   })
 }
 
-// eslint-disable-next-line no-undef
-ipcApi = {
+contextBridge.exposeInMainWorld('ipcApi', {
 
   /**
    * Initializes the renderer process so this API can be used.
@@ -66,4 +65,4 @@ ipcApi = {
   eventStats (messageId, windowId, event) {
     sendStats({ messageId, windowId, event })
   }
-}
+})


### PR DESCRIPTION
Electron-pdf was already using a single ipcApi object to expose all
functionality required in the web page context. However, the ipcApi
object itself was referenced directly, without going through the
contextBridge API.

Here we ensure that context isolation is enabled and share the ipcApi
object with the website ("main world") context. Note that having context
isolation enabled is now the default, so this should be the safer option
moving forward.

Fixes #289 